### PR TITLE
fix typo in lab6/README.md

### DIFF
--- a/lab6/README.md
+++ b/lab6/README.md
@@ -16,9 +16,7 @@ All your code should be in the `lab6` namespace.
 A partial solution is present in the `partial/` directory.
 You should start there.
 
-Run `make` to build the project. The compiler will try to compile `tests.m.cpp`
-and immediately complain that the header file `library.cpp` was included but
-does not yet exist.
+Run `make` to build the project.
 
 
 ## 1. Use move semantics in the constructor of `Book`


### PR DESCRIPTION
Unless the intent was to leave `library.cpp` out of lab6, I believe this is a typo.

--

P.S. thank you for the course. It was very well done.